### PR TITLE
Specify excon version

### DIFF
--- a/field_struct_avro_schema.gemspec
+++ b/field_struct_avro_schema.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'field_struct'
   spec.add_dependency 'avro', '~> 1.9.2'
   spec.add_dependency 'avro-builder'
-  spec.add_dependency 'excon'
+  spec.add_dependency 'excon', '~> 0.89'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry'


### PR DESCRIPTION
Locks on excon version to prevent from isntalling excon in other acima projects from acima package registry. In https://github.com/acima-credit/sf_shared_models/pull/43 `excon 0.76.0.cc` was pulled which is a special version of excon added to the Acima package registery for credit card service. This was pulled in this way because field_struct_avro_schema requires excon but with no version specified and I think field_struct_avro_schema should be updated to place a version on excon so that this doesn't happen.