### PR TITLE
[LMS-12784] Fix rounding issue during converting float to currency

### DIFF
--- a/lib/field_struct/avro_schema/value_converters/currency_converter.rb
+++ b/lib/field_struct/avro_schema/value_converters/currency_converter.rb
@@ -7,7 +7,7 @@ module FieldStruct
         handles :currency
 
         def to_avro
-          (value * 100).to_i
+          (value * 100).round
         end
 
         def from_avro

--- a/lib/field_struct/avro_schema/version.rb
+++ b/lib/field_struct/avro_schema/version.rb
@@ -2,6 +2,6 @@
 
 module FieldStruct
   module AvroSchema
-    VERSION = '0.1.18'
+    VERSION = '0.1.19'
   end
 end

--- a/spec/lib/field_struct/avro_schema/value_converters/currency_converter_spec.rb
+++ b/spec/lib/field_struct/avro_schema/value_converters/currency_converter_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FieldStruct::AvroSchema::ValueConverters::CurrencyConverter do
+  describe '.to_avro' do
+    it 'converts amount as float to currency' do
+      result = described_class.to_avro(74.99)
+      expect(result).to eq(7499)
+    end
+
+    it 'converts amount as int to currency' do
+      result = described_class.to_avro(75)
+      expect(result).to eq(7500)
+    end
+  end
+end


### PR DESCRIPTION
https://acima.atlassian.net/browse/LMS-12784

This PR fixes problem that we experience in LMS. We try to serialize the currency field with for example `74.99` as value. After deserialization we receive `74.98`.

I found out that this is caused by the following code
```ruby
def to_avro
  (value * 100).to_i
end
```
```ruby
pry(main)> (74.99 * 100)
=> 7498.999999999999
pry(main)> (74.99 * 100).to_i
=> 7498
```

Looks that `to_i` calls somewhere `floor` which round this down. Using `round` seems to be the correct solution. Perhaps maybe it would be better to use `money` gem here but from the other side, I understand that using an additional external library for such simple functionality may be a bit overuse.

### Testing scenarios 
Just run tests added in this PR

