### PR TITLE
Zach/integrate avro acima

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   SuggestExtensions: false
   NewCops: enable
   Include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 sudo: false
-language: ruby
+language: \ruby
 cache: bundler
 rvm:
-  - 2.6.3
-before_install: gem install bundler -v 2.0.2
+  - 2.7.0
+before_install: gem install bundler -v 2.2.32

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM ruby:2.6.3-alpine as base
+FROM ruby:2.7-alpine as base
 
 RUN apk update && apk upgrade && apk --no-cache add \
   tzdata \

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 
 source 'https://rubygems.pkg.github.com/acima-credit/' do
-  gem 'field_struct', '0.2.26.pre.6329b11'
+  gem 'field_struct', '0.2.27'
   gem 'avro_acima', '0.3.0.pre'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source 'https://rubygems.org'
 
-gem 'field_struct', git: 'https://github.com/acima-credit/field_struct.git'
+source 'https://rubygems.pkg.github.com/acima-credit/' do
+  gem 'field_struct', '0.2.26.pre.6329b11'
+end
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 source 'https://rubygems.pkg.github.com/acima-credit/' do
   gem 'field_struct', '0.2.26.pre.6329b11'
+  gem 'avro_acima', '0.3.0.pre'
 end
 
 gemspec

--- a/field_struct_avro_schema.gemspec
+++ b/field_struct_avro_schema.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport'
   spec.add_dependency 'activemodel'
   spec.add_dependency 'avro', '~> 1.11.0'
-  spec.add_dependency 'avro_acima', '0.3.0.pre'
   spec.add_dependency 'avro-builder'
   spec.add_dependency 'excon'
 

--- a/field_struct_avro_schema.gemspec
+++ b/field_struct_avro_schema.gemspec
@@ -37,8 +37,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport'
   spec.add_dependency 'activemodel'
-  spec.add_dependency 'field_struct'
-  spec.add_dependency 'avro', '~> 1.9.2'
+  spec.add_dependency 'avro', '~> 1.11.0'
+  spec.add_dependency 'avro_acima', '0.3.0.pre'
   spec.add_dependency 'avro-builder'
   spec.add_dependency 'excon'
 

--- a/lib/field_struct/avro_schema.rb
+++ b/lib/field_struct/avro_schema.rb
@@ -8,5 +8,7 @@ require 'active_support'
 require 'excon'
 require 'field_struct'
 require 'avro/builder'
+require 'avro_acima'
 
+require_relative 'ext/sensitive_data'
 require_relative 'avro_schema/avro_schema'

--- a/lib/field_struct/avro_schema/builders/avro_builder.rb
+++ b/lib/field_struct/avro_schema/builders/avro_builder.rb
@@ -49,7 +49,8 @@ module FieldStruct
                    type_parts.join('.').inspect
                  elsif attr[:logical_type] == 'sensitive-data'
                    field_id = attr.dig(:avro, :field_id)
-                   raise "Missing field_id" unless field_id
+                   raise 'Missing field_id' unless field_id
+
                    "AvroBuilder::Extensions::SensitiveData.new(cache: nil, field_id: '#{field_id}')"
                  else
                    ":#{attr[:type]}"
@@ -210,7 +211,7 @@ module FieldStruct
       end
 
       def logical_type_tuple(attr, type)
-        if !attr.avro.nil? && attr.avro.has_key?(:logical_type)
+        if !attr.avro.nil? && attr.avro.key?(:logical_type)
           [type, attr.avro[:logical_type]]
         elsif (type_ary = LOGICAL_TYPES[type])
           type_ary

--- a/lib/field_struct/avro_schema/builders/avro_builder.rb
+++ b/lib/field_struct/avro_schema/builders/avro_builder.rb
@@ -47,6 +47,10 @@ module FieldStruct
           type_parts = attr[:type].to_s.split('.')
           ary << if type_parts.size > 1
                    type_parts.join('.').inspect
+                 elsif attr[:logical_type] == 'sensitive-data'
+                   field_id = attr.dig(:avro, :field_id)
+                   raise "Missing field_id" unless field_id
+                   "AvroBuilder::Extensions::SensitiveData.new(cache: nil, field_id: '#{field_id}')"
                  else
                    ":#{attr[:type]}"
                  end
@@ -158,7 +162,8 @@ module FieldStruct
       def build_attribute(name, attr)
         hsh = {
           name: name,
-          mode: attr.required? ? :required : :optional
+          mode: attr.required? ? :required : :optional,
+          avro: attr.avro
         }
         add_field_type_for attr, hsh
         add_field_default_for attr, hsh
@@ -183,7 +188,7 @@ module FieldStruct
 
         hsh[:type] = :array
         type = attr.of
-        if (type_ary = LOGICAL_TYPES[type])
+        if (type_ary = logical_type_tuple(attr, type))
           hsh[:items] = type_ary
         elsif (type_key = ACTIVE_MODEL_TYPES[type])
           hsh[:items] = type_key.to_s
@@ -194,13 +199,21 @@ module FieldStruct
 
       def add_single_field_type_for(attr, hsh)
         type = attr.type
-        if (type_ary = LOGICAL_TYPES[type])
+        if (type_ary = logical_type_tuple(attr, type))
           hsh[:type] = type_ary.first.to_s
           hsh[:logical_type] = type_ary.last
         elsif (type_key = ACTIVE_MODEL_TYPES[type])
           hsh[:type] = type_key.to_s
         elsif type.field_struct?
           hsh[:type] = type.schema_record_name
+        end
+      end
+
+      def logical_type_tuple(attr, type)
+        if !attr.avro.nil? && attr.avro.has_key?(:logical_type)
+          [type, attr.avro[:logical_type]]
+        elsif (type_ary = LOGICAL_TYPES[type])
+          type_ary
         end
       end
 

--- a/lib/field_struct/avro_schema/builders/metadata_builder.rb
+++ b/lib/field_struct/avro_schema/builders/metadata_builder.rb
@@ -114,7 +114,7 @@ module FieldStruct
       end
 
       def initialize(schemas, options = {})
-        @schemas = Array([schemas]).flatten
+        @schemas = [schemas].flatten
         @options = self.class.default_options.merge(schema_names: {}).merge(options)
         @dependencies = []
         @results = []

--- a/lib/field_struct/avro_schema/converters/from_avro.rb
+++ b/lib/field_struct/avro_schema/converters/from_avro.rb
@@ -22,7 +22,7 @@ module FieldStruct
         end
 
         def convert
-          klass.new **convert_attributes
+          klass.new(**convert_attributes)
         end
 
         private

--- a/lib/field_struct/avro_schema/converters/from_avro.rb
+++ b/lib/field_struct/avro_schema/converters/from_avro.rb
@@ -22,7 +22,7 @@ module FieldStruct
         end
 
         def convert
-          klass.new convert_attributes
+          klass.new **convert_attributes
         end
 
         private

--- a/lib/field_struct/avro_schema/converters/to_avro.rb
+++ b/lib/field_struct/avro_schema/converters/to_avro.rb
@@ -41,8 +41,8 @@ module FieldStruct
         end
       end
 
-      def self.to_avro(*args)
-        ToAvro.new(*args).convert
+      def self.to_avro(*args, **kwargs)
+        ToAvro.new(*args, **kwargs).convert
       end
     end
   end

--- a/lib/field_struct/avro_schema/event.rb
+++ b/lib/field_struct/avro_schema/event.rb
@@ -130,7 +130,7 @@ module FieldStruct
       end
 
       def to_avro_messaging
-        ::FieldStruct::AvroSchema::Kafka.encode_avro to_avro_hash, schema_id: schema_id
+        ::FieldStruct::AvroSchema::Kafka.encode_avro **to_avro_hash, schema_id: schema_id
       end
     end
   end

--- a/lib/field_struct/avro_schema/event.rb
+++ b/lib/field_struct/avro_schema/event.rb
@@ -130,7 +130,7 @@ module FieldStruct
       end
 
       def to_avro_messaging
-        ::FieldStruct::AvroSchema::Kafka.encode_avro **to_avro_hash, schema_id: schema_id
+        ::FieldStruct::AvroSchema::Kafka.encode_avro to_avro_hash, schema_id: schema_id
       end
     end
   end

--- a/lib/field_struct/avro_schema/kafka.rb
+++ b/lib/field_struct/avro_schema/kafka.rb
@@ -107,16 +107,16 @@ module FieldStruct
         raise e
       end
 
-      def encode_avro(*args)
-        AvroEncoder.encode(*args)
+      def encode_avro(*args, **kwargs)
+        AvroEncoder.encode(*args, **kwargs)
       end
 
-      def encode_json(*args)
-        JsonEncoder.encode(*args)
+      def encode_json(*args, **kwargs)
+        JsonEncoder.encode(*args, **kwargs)
       end
 
-      def encode_string(*args)
-        StringEncoder.encode(*args)
+      def encode_string(*args, **kwargs)
+        StringEncoder.encode(*args, **kwargs)
       end
 
       def decode(payload, topic)

--- a/lib/field_struct/avro_schema/kafka/coders/avro_encoder.rb
+++ b/lib/field_struct/avro_schema/kafka/coders/avro_encoder.rb
@@ -31,9 +31,9 @@ module FieldStruct
         def fetch_schema_from_registry
           fetch_schema_by_id || fetch_schema || register_schema || missing_get_schema_args
         rescue Excon::Error::NotFound
-          raise SchemaNotFoundError, "Schema with id: #{schema_id} is not found on registry" if schema_id
+          raise SchemaNotFoundError, "Schema with id: #{@schema_id} is not found on registry" if @schema_id
 
-          raise SchemaNotFoundError, "Schema with subject: `#{subject}` version: `#{version}` is not found on registry"
+          raise SchemaNotFoundError, "Schema with subject: `#{@subject}` version: `#{@version}` is not found on registry"
         end
 
         def fetch_schema_by_id

--- a/lib/field_struct/avro_schema/kafka/coders/avro_encoder.rb
+++ b/lib/field_struct/avro_schema/kafka/coders/avro_encoder.rb
@@ -33,7 +33,8 @@ module FieldStruct
         rescue Excon::Error::NotFound
           raise SchemaNotFoundError, "Schema with id: #{@schema_id} is not found on registry" if @schema_id
 
-          raise SchemaNotFoundError, "Schema with subject: `#{@subject}` version: `#{@version}` is not found on registry"
+          raise SchemaNotFoundError,
+                "Schema with subject: `#{@subject}` version: `#{@version}` is not found on registry"
         end
 
         def fetch_schema_by_id

--- a/lib/field_struct/avro_schema/kafka/coders/base_decoder.rb
+++ b/lib/field_struct/avro_schema/kafka/coders/base_decoder.rb
@@ -4,11 +4,11 @@ module FieldStruct
   module AvroSchema
     module Kafka
       class BaseDecoder
-        def self.decode(*args)
-          new(*args).decode
+        def self.decode(*args, **kwargs)
+          new(*args, **kwargs).decode
         end
 
-        def initialize(payload, *_args)
+        def initialize(payload, *_args, **kwargs)
           @data = payload.to_s
         end
 

--- a/lib/field_struct/avro_schema/kafka/coders/base_decoder.rb
+++ b/lib/field_struct/avro_schema/kafka/coders/base_decoder.rb
@@ -8,7 +8,7 @@ module FieldStruct
           new(*args, **kwargs).decode
         end
 
-        def initialize(payload, *_args, **kwargs)
+        def initialize(payload, *_args, **_kwargs)
           @data = payload.to_s
         end
 

--- a/lib/field_struct/avro_schema/kafka/coders/base_decoder.rb
+++ b/lib/field_struct/avro_schema/kafka/coders/base_decoder.rb
@@ -4,11 +4,11 @@ module FieldStruct
   module AvroSchema
     module Kafka
       class BaseDecoder
-        def self.decode(*args, **kwargs)
-          new(*args, **kwargs).decode
+        def self.decode(*args)
+          new(*args).decode
         end
 
-        def initialize(payload, *_args, **kwargs)
+        def initialize(payload, *_args)
           @data = payload.to_s
         end
 

--- a/lib/field_struct/avro_schema/kafka/coders/base_encoder.rb
+++ b/lib/field_struct/avro_schema/kafka/coders/base_encoder.rb
@@ -4,11 +4,11 @@ module FieldStruct
   module AvroSchema
     module Kafka
       class BaseEncoder
-        def self.encode(*args, **kwargs)
-          new(*args, **kwargs).encode
+        def self.encode(*args)
+          new(*args).encode
         end
 
-        def initialize(message, *_args, **kwargs)
+        def initialize(message, *_args)
           @message = prepare_message message
         end
 

--- a/lib/field_struct/avro_schema/kafka/coders/base_encoder.rb
+++ b/lib/field_struct/avro_schema/kafka/coders/base_encoder.rb
@@ -8,7 +8,7 @@ module FieldStruct
           new(*args, **kwargs).encode
         end
 
-        def initialize(message, *_args, **kwargs)
+        def initialize(message, *_args, **_kwargs)
           @message = prepare_message message
         end
 

--- a/lib/field_struct/avro_schema/kafka/coders/base_encoder.rb
+++ b/lib/field_struct/avro_schema/kafka/coders/base_encoder.rb
@@ -4,11 +4,11 @@ module FieldStruct
   module AvroSchema
     module Kafka
       class BaseEncoder
-        def self.encode(*args)
-          new(*args).encode
+        def self.encode(*args, **kwargs)
+          new(*args, **kwargs).encode
         end
 
-        def initialize(message, *_args)
+        def initialize(message, *_args, **kwargs)
           @message = prepare_message message
         end
 

--- a/lib/field_struct/avro_schema/version.rb
+++ b/lib/field_struct/avro_schema/version.rb
@@ -2,6 +2,6 @@
 
 module FieldStruct
   module AvroSchema
-    VERSION = '0.1.20'
+    VERSION = '0.1.21'
   end
 end

--- a/lib/field_struct/avro_schema/version.rb
+++ b/lib/field_struct/avro_schema/version.rb
@@ -2,6 +2,6 @@
 
 module FieldStruct
   module AvroSchema
-    VERSION = '0.1.21'
+    VERSION = '0.1.22'
   end
 end

--- a/lib/field_struct/ext/sensitive_data.rb
+++ b/lib/field_struct/ext/sensitive_data.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# This is an AvroBuilder type that permits serializing sensitive-data schema elements
+module AvroBuilder
+  module Extensions
+    class SensitiveData < Avro::Builder::Types::Type
+      dsl_attributes(:field_id)
+
+      def initialize(cache: nil, field: nil, field_id: nil)
+        @logical_type = 'sensitive-data'
+        @abstract = true
+        @field_id = field_id
+        super('string', field: field, cache: cache)
+      end
+
+      def serialize(reference_state, overrides: {})
+        super(reference_state, overrides: serialized_attributes)
+      end
+
+      def to_h(reference_state, overrides: {})
+        super(reference_state, overrides: serialized_attributes)
+      end
+
+      def validate!
+        super
+        validate_required_attribute!(:field_id)
+      end
+
+      private
+
+      def serialized_attributes
+        { fieldId: @field_id }
+      end
+    end
+  end
+end
+

--- a/lib/field_struct/ext/sensitive_data.rb
+++ b/lib/field_struct/ext/sensitive_data.rb
@@ -13,11 +13,11 @@ module AvroBuilder
         super('string', field: field, cache: cache)
       end
 
-      def serialize(reference_state, overrides: {})
+      def serialize(reference_state, _overrides: {})
         super(reference_state, overrides: serialized_attributes)
       end
 
-      def to_h(reference_state, overrides: {})
+      def to_h(reference_state, _overrides: {})
         super(reference_state, overrides: serialized_attributes)
       end
 
@@ -34,4 +34,3 @@ module AvroBuilder
     end
   end
 end
-

--- a/spec/cassettes/Examples_User/event/encoding_and_decoding/avro/encodes_properly.yml
+++ b/spec/cassettes/Examples_User/event/encoding_and_decoding/avro/encodes_properly.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:8081/schemas/ids/10
+    uri: http://localhost:8081/schemas/ids/1
     body:
       encoding: US-ASCII
       string: ''
@@ -12,26 +12,29 @@ http_interactions:
   response:
     status:
       code: 200
-      message: null
+      message:
     headers:
       Date:
-      - Thu, 03 Feb 2022 01:18:58 GMT
+      - Mon, 16 Oct 2023 20:07:20 GMT
+      X-Request-ID:
+      - 640dccb1-e231-44fc-8e63-581e5487f3c8
       Content-Type:
       - application/vnd.schemaregistry.v1+json
       Vary:
       - Accept-Encoding, User-Agent
       Content-Length:
-      - '809'
+      - '987'
     body:
       encoding: ASCII-8BIT
       string: '{"schema":"{\"type\":\"record\",\"name\":\"user\",\"namespace\":\"examples\",\"doc\":\"|
-        version 53d47729\",\"fields\":[{\"name\":\"username\",\"type\":\"string\",\"doc\":\"login
+        version daff3d9a\",\"fields\":[{\"name\":\"username\",\"type\":\"string\",\"doc\":\"login
         | type string\"},{\"name\":\"password\",\"type\":[\"null\",\"string\"],\"doc\":\"|
         type string\",\"default\":null},{\"name\":\"age\",\"type\":\"int\",\"doc\":\"|
         type integer\"},{\"name\":\"owed\",\"type\":\"int\",\"doc\":\"amount owed
         to the company | type currency\"},{\"name\":\"source\",\"type\":\"string\",\"doc\":\"|
         type string\"},{\"name\":\"level\",\"type\":\"int\",\"doc\":\"| type integer\"},{\"name\":\"at\",\"type\":[\"null\",{\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}],\"doc\":\"|
         type time\",\"default\":null},{\"name\":\"active\",\"type\":\"boolean\",\"doc\":\"|
-        type boolean\",\"default\":false}]}"}'
-  recorded_at: Thu, 03 Feb 2022 01:18:58 GMT
-recorded_with: VCR 6.0.0
+        type boolean\",\"default\":false},{\"name\":\"ssn\",\"type\":[\"null\",{\"type\":\"string\",\"logicalType\":\"sensitive-data\",\"fieldId\":\"social_security_number\"}],\"doc\":\"|
+        type string\",\"default\":null}]}"}'
+  recorded_at: Mon, 16 Oct 2023 20:07:20 GMT
+recorded_with: VCR 6.2.0

--- a/spec/cassettes/Examples_User/event/registration/registers_with_schema_registry.yml
+++ b/spec/cassettes/Examples_User/event/registration/registers_with_schema_registry.yml
@@ -6,7 +6,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"schema":"{\n  \"type\": \"record\",\n  \"name\": \"user\",\n  \"namespace\":
-        \"examples\",\n  \"doc\": \"| version 53d47729\",\n  \"fields\": [\n    {\n      \"name\":
+        \"examples\",\n  \"doc\": \"| version daff3d9a\",\n  \"fields\": [\n    {\n      \"name\":
         \"username\",\n      \"type\": \"string\",\n      \"doc\": \"login | type
         string\"\n    },\n    {\n      \"name\": \"password\",\n      \"type\": [\n        \"null\",\n        \"string\"\n      ],\n      \"default\":
         null,\n      \"doc\": \"| type string\"\n    },\n    {\n      \"name\": \"age\",\n      \"type\":
@@ -18,25 +18,31 @@ http_interactions:
         \"at\",\n      \"type\": [\n        \"null\",\n        {\n          \"type\":
         \"long\",\n          \"logicalType\": \"timestamp-millis\"\n        }\n      ],\n      \"default\":
         null,\n      \"doc\": \"| type time\"\n    },\n    {\n      \"name\": \"active\",\n      \"type\":
-        \"boolean\",\n      \"default\": false,\n      \"doc\": \"| type boolean\"\n    }\n  ]\n}"}'
+        \"boolean\",\n      \"default\": false,\n      \"doc\": \"| type boolean\"\n    },\n    {\n      \"name\":
+        \"ssn\",\n      \"type\": [\n        \"null\",\n        {\n          \"type\":
+        \"string\",\n          \"logicalType\": \"sensitive-data\",\n          \"fieldId\":
+        \"social_security_number\"\n        }\n      ],\n      \"default\": null,\n      \"doc\":
+        \"| type string\"\n    }\n  ]\n}"}'
     headers:
       Content-Type:
       - application/vnd.schemaregistry.v1+json
   response:
     status:
       code: 200
-      message: null
+      message:
     headers:
       Date:
-      - Thu, 03 Feb 2022 01:12:55 GMT
+      - Mon, 16 Oct 2023 20:07:43 GMT
+      X-Request-ID:
+      - 4c07d371-d01c-4f68-ba1c-230b5157bdac
       Content-Type:
       - application/vnd.schemaregistry.v1+json
       Vary:
       - Accept-Encoding, User-Agent
       Content-Length:
-      - '9'
+      - '8'
     body:
       encoding: ASCII-8BIT
-      string: '{"id":10}'
-  recorded_at: Thu, 03 Feb 2022 01:12:55 GMT
-recorded_with: VCR 6.0.0
+      string: '{"id":1}'
+  recorded_at: Mon, 16 Oct 2023 20:07:43 GMT
+recorded_with: VCR 6.2.0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,8 @@
 
 require 'bundler/setup'
 require 'field_struct/avro_schema'
+require "avro_acima/encryption/dummy_encryption_provider"
+require 'fileutils'
 
 FieldStruct::AvroSchema.logger.level = ENV.fetch('LOG_LEVEL', Logger::INFO).to_i
 
@@ -56,4 +58,8 @@ VCR.configure do |c|
   c.hook_into :excon
   c.configure_rspec_metadata!
   # c.allow_http_connections_when_no_cassette = true
+end
+
+AvroAcima.configure do |c|
+  c.encryption_provider = AvroAcima::Encryption::DummyEncryptionProvider.new
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 
 require 'bundler/setup'
 require 'field_struct/avro_schema'
-require "avro_acima/encryption/dummy_encryption_provider"
+require 'avro_acima/encryption/dummy_encryption_provider'
 require 'fileutils'
 
 FieldStruct::AvroSchema.logger.level = ENV.fetch('LOG_LEVEL', Logger::INFO).to_i

--- a/spec/structs/company_spec.rb
+++ b/spec/structs/company_spec.rb
@@ -534,8 +534,8 @@ RSpec.describe Examples::Company do
       let(:exp_encoded) do
         '{"legal_name":"My Super Company","development_team":{"name":"Duper Team","leader":{"first_name":"Karl","las' \
           't_name":"Marx","title":"Team Lead"},"members":[{"first_name":"John","last_name":"Stalingrad","title":"Dev' \
-          'eloper","language":"Ruby"},{"first_name":"Steve","last_name":"Romanoff","title":"Designer","language":"In' \
-          ' Design"}]},"marketing_team":{"name":"Growing Team","leader":{"first_name":"Evan","last_name":"Majors","t' \
+          'eloper","language":"Ruby"},{"first_name":"Steve","last_name":"Romanoff","title":"Designer","language":"In ' \
+          'Design"}]},"marketing_team":{"name":"Growing Team","leader":{"first_name":"Evan","last_name":"Majors","t' \
           'itle":"Team Lead"},"members":[{"first_name":"Rob","last_name":"Morris","title":"Developer","language":"Ja' \
           'vascript"},{"first_name":"Zach","last_name":"Evanoff","title":"Designer","language":"Photoshop"}]}}'
       end

--- a/spec/structs/user_spec.rb
+++ b/spec/structs/user_spec.rb
@@ -4,13 +4,13 @@ require 'spec_helper'
 
 RSpec.describe Examples::User do
   subject { described_class.metadata }
-  let(:exp_schema_id) { 10 }
+  let(:exp_schema_id) { 1 }
 
   let(:exp_hash) do
     {
       name: 'Examples::User',
       schema_name: 'examples.user',
-      version: '53d47729',
+      version: 'daff3d9a',
       attributes: {
         username: { type: :string, required: true, format: /\A[a-z]/i, description: 'login' },
         password: { type: :string },
@@ -19,7 +19,8 @@ RSpec.describe Examples::User do
         source: { type: :string, required: true, enum: %w[A B C] },
         level: { type: :integer, required: true, default: '<proc>' },
         at: { type: :time },
-        active: { type: :boolean, required: true, default: false }
+        active: { type: :boolean, required: true, default: false },
+        ssn: { type: :string, avro: { logical_type: 'sensitive-data', field_id: 'social_security_number'} }
       }
     }
   end
@@ -27,7 +28,7 @@ RSpec.describe Examples::User do
     <<~CODE.chomp
       namespace 'examples'
 
-      record :user, :doc=>"| version 53d47729" do
+      record :user, :doc=>"| version daff3d9a" do
         required :username, :string, doc: "login | type string"
         optional :password, :string, doc: "| type string"
         required :age, :int, doc: "| type integer"
@@ -36,6 +37,7 @@ RSpec.describe Examples::User do
         required :level, :int, doc: "| type integer"
         optional :at, :long, logical_type: "timestamp-millis", doc: "| type time"
         required :active, :boolean, default: false, doc: "| type boolean"
+        optional :ssn, AvroBuilder::Extensions::SensitiveData.new(cache: nil, field_id: 'social_security_number'), logical_type: "sensitive-data", doc: "| type string"
       end
     CODE
   end
@@ -44,7 +46,7 @@ RSpec.describe Examples::User do
       type: 'record',
       name: 'user',
       namespace: 'examples',
-      doc: '| version 53d47729',
+      doc: '| version daff3d9a',
       fields: [
         { name: 'username', type: 'string', doc: 'login | type string' },
         { name: 'password', type: %w[null string], default: nil, doc: '| type string' },
@@ -58,7 +60,13 @@ RSpec.describe Examples::User do
           default: nil,
           doc: '| type time'
         },
-        { name: 'active', type: 'boolean', default: false, doc: '| type boolean' }
+        { name: 'active', type: 'boolean', default: false, doc: '| type boolean' },
+        {
+          name: 'ssn',
+          type: ['null', { type: 'string', logicalType: 'sensitive-data', fieldId: 'social_security_number'}],
+          default: nil,
+          doc: '| type string'
+        }
       ]
     }
   end
@@ -68,7 +76,7 @@ RSpec.describe Examples::User do
         "type": "record",
         "name": "user",
         "namespace": "examples",
-        "doc": "| version 53d47729",
+        "doc": "| version daff3d9a",
         "fields": [
           {
             "name": "username",
@@ -121,6 +129,19 @@ RSpec.describe Examples::User do
             "type": "boolean",
             "default": false,
             "doc": "| type boolean"
+          },
+          {
+            "name": "ssn",
+            "type": [
+              "null",
+              {
+                "type": "string",
+                "logicalType": "sensitive-data",
+                "fieldId": "social_security_number"
+              }
+            ],
+            "default": null,
+            "doc": "| type string"
           }
         ]
       }
@@ -129,9 +150,9 @@ RSpec.describe Examples::User do
   let(:exp_version_meta) do
     [
       {
-        name: 'Schemas::Examples::User::V53d47729',
-        schema_name: 'schemas.examples.user.v53d47729',
-        version: '53d47729',
+        name: 'Schemas::Examples::User::Vdaff3d9a',
+        schema_name: 'schemas.examples.user.vdaff3d9a',
+        version: 'daff3d9a',
         attributes: {
           username: { type: :string, required: true, description: 'login' },
           password: { type: :string },
@@ -140,7 +161,8 @@ RSpec.describe Examples::User do
           source: { type: :string, required: true },
           level: { type: :integer, required: true },
           at: { type: :time },
-          active: { type: :boolean, required: true, default: false }
+          active: { type: :boolean, required: true, default: false },
+          ssn: { type: :string }
         }
       }
     ]
@@ -185,6 +207,7 @@ RSpec.describe Examples::User do
       expect(original.level).to eq 2
       expect(original.at).to eq past_time
       expect(original.active).to eq true
+      expect(original.ssn).to eq '123-45-6789'
 
       expect { blt_klas }.to_not raise_error
 
@@ -199,6 +222,7 @@ RSpec.describe Examples::User do
       expect(clone.level).to eq 2
       expect(clone.at).to eq past_time
       expect(clone.active).to eq true
+      expect(clone.ssn).to eq '123-45-6789'
     end
   end
 
@@ -217,7 +241,8 @@ RSpec.describe Examples::User do
         source: 'B',
         level: 2,
         at: 1_551_701_167_891,
-        active: true
+        active: true,
+        ssn: '123-45-6789'
       }
     end
     let(:exp_hsh) do
@@ -229,7 +254,8 @@ RSpec.describe Examples::User do
         source: 'B',
         level: 2,
         at: past_time.utc,
-        active: true
+        active: true,
+        ssn: '123-45-6789'
       }
     end
     it('#to_avro_hash') { compare instance.to_avro_hash, exp_avro_hsh }
@@ -255,12 +281,12 @@ RSpec.describe Examples::User do
     let(:new_topic_name) { 'some.topic' }
     let(:new_topic_key) { :other }
     let(:exp_avro_encoded) do
-      "\u0000\u0000\u0000\u0000\n\u0012some_user\u0002\u001Asome_passwordZ\xFA\xE1" \
-        "\u0012\u0002B\u0004\u0002\xA6\xBCƉ\xA9Z\u0001"
+      "\u0000\u0000\u0000\u0000\u0001\u0012some_user\u0002\u001Asome_passwordZ\xFA\xE1" \
+        "\u0012\u0002B\u0004\u0002\xA6\xBCƉ\xA9Z\u0001\u0002XENCRYPTED:social_security_number:123-45-6789"
     end
     let(:exp_json_encoded) do
       '{"username":"some_user","password":"some_password","age":45,"owed":1537.25,"source":"B","level":2,"at":' \
-        '"2019-03-04T05:06:07.891-07:00","active":true}'
+        '"2019-03-04T05:06:07.891-07:00","active":true,"ssn":"123-45-6789"}'
     end
 
     context 'class' do
@@ -330,7 +356,7 @@ RSpec.describe Examples::User do
         let(:encoded) { instance.topic_encoded(:json) }
         let(:exp_encoded) do
           '{"username":"some_user","password":"some_password","age":45,"owed":1537.25,"source":"B","level":2,"at":' \
-            '"2019-03-04T05:06:07.891-07:00","active":true}'
+            '"2019-03-04T05:06:07.891-07:00","active":true,"ssn":"123-45-6789"}'
         end
         let(:exp_decoded) { JSON.parse instance.to_hash.to_json }
         it('encodes properly') { compare encoded, exp_encoded }
@@ -369,7 +395,8 @@ RSpec.describe Examples::User do
               source: 'B',
               level: 2,
               at: past_time.utc,
-              active: true
+              active: true,
+              ssn: '123-45-6789'
             }
           end
           it('decodes') { compare result, exp_hsh }

--- a/spec/structs/user_spec.rb
+++ b/spec/structs/user_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Examples::User do
         level: { type: :integer, required: true, default: '<proc>' },
         at: { type: :time },
         active: { type: :boolean, required: true, default: false },
-        ssn: { type: :string, avro: { logical_type: 'sensitive-data', field_id: 'social_security_number'} }
+        ssn: { type: :string, avro: { logical_type: 'sensitive-data', field_id: 'social_security_number' } }
       }
     }
   end
@@ -63,7 +63,7 @@ RSpec.describe Examples::User do
         { name: 'active', type: 'boolean', default: false, doc: '| type boolean' },
         {
           name: 'ssn',
-          type: ['null', { type: 'string', logicalType: 'sensitive-data', fieldId: 'social_security_number'}],
+          type: ['null', { type: 'string', logicalType: 'sensitive-data', fieldId: 'social_security_number' }],
           default: nil,
           doc: '| type string'
         }
@@ -378,7 +378,7 @@ RSpec.describe Examples::User do
         end
         context 'other' do
           let(:instance) { ExampleApp::Examples::Stranger.new name: 'unknown', age: 25 }
-          it('raises error') { expect { result }.to raise_error ::Karafka::Errors::SerializationError, instance }
+          it('raises error') { expect { result }.to raise_error Karafka::Errors::SerializationError, instance }
         end
       end
       context 'deserialization' do
@@ -407,7 +407,7 @@ RSpec.describe Examples::User do
         end
         context 'other' do
           let(:raw_payload) { { a: 1 }.to_json }
-          it('raises error') { expect { result }.to raise_error ::Karafka::Errors::DeserializationError }
+          it('raises error') { expect { result }.to raise_error Karafka::Errors::DeserializationError }
         end
       end
     end

--- a/spec/support/compare.rb
+++ b/spec/support/compare.rb
@@ -37,8 +37,8 @@ module CompareHelpers
       compare act, exp, "#{prefix}[#{k}]"
     end
     expect(act_hash.keys.sort).to eq(exp_hash.keys.sort),
-                                  "expected actual keys #{prefix} #{act_hash.keys.inspect}\n" \
-                                  "          to eq keys #{prefix} #{exp_hash.keys.inspect}\n" \
+                                  "expected actual keys #{prefix} #{act_hash.keys.inspect}\n          " \
+                                  "to eq keys #{prefix} #{exp_hash.keys.inspect}\n" \
                                   'but were different'
   end
 
@@ -51,8 +51,8 @@ module CompareHelpers
       compare act_val, exp_val, "#{prefix}[#{idx}]"
     end
     expect(act_ary.size).to eq(exp_ary.size),
-                            "expected actual size #{prefix} #{act_ary.size}\n" \
-                            "          to eq size #{prefix} #{exp_ary.size}\n" \
+                            "expected actual size #{prefix} #{act_ary.size}\n          " \
+                            "to eq size #{prefix} #{exp_ary.size}\n" \
                             'but was different'
   end
 

--- a/spec/support/model_helpers.rb
+++ b/spec/support/model_helpers.rb
@@ -14,7 +14,8 @@ module ModelHelpers
       source: 'B',
       level: 2,
       at: past_time,
-      active: true
+      active: true,
+      ssn: '123-45-6789'
     }
   end
 

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -21,6 +21,7 @@ module Examples
     required :level, :integer, default: -> { 2 }
     optional :at, :time
     required :active, :boolean, default: false
+    optional :ssn, :string, avro: { logical_type: 'sensitive-data', field_id: 'social_security_number' }
   end
 
   class Person < Base


### PR DESCRIPTION
This PR:
- integrates [avro_acima](https://github.com/acima-credit/avro-acima) in order to use the `sensitive-data` logical type.
- relies on [work](https://github.com/acima-credit/field_struct/pull/15) in field_struct to enable passing some avro metadata through 
- currently depends on prerelease versions of both field_struct and avro_acima. Once those are released, I will update this PR.
- bumps up the minimum required version of avro
- builds on @matthewrampey's work to make this gem ruby 3 compatible