### PR TITLE
Zach/bump avro acima

### DIFF
--- a/.github/workflows/publish-on-push.yaml
+++ b/.github/workflows/publish-on-push.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build and publish gem
-      uses: jstastny/publish-gem-to-github@v2.1
+      uses: jstastny/publish-gem-to-github@master
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         owner: acima-credit

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 source 'https://rubygems.pkg.github.com/acima-credit/' do
   gem 'field_struct', '0.2.27'
-  gem 'avro_acima', '0.3.0.pre'
+  gem 'avro_acima', '0.3.1'
 end
 
 gemspec


### PR DESCRIPTION
avro_acima 0.3.1 has a bugfix to prevent sensitive data from being written to logs (via an exception message).

Question: how do you want to handle FSAS's version number here? Leave it since this is a patch-level change in a dependency? Or bump it?