### PR TITLE
Update Ruby Pkg Publisher

### DIFF
--- a/.github/workflows/publish-on-push.yaml
+++ b/.github/workflows/publish-on-push.yaml
@@ -4,12 +4,13 @@ on:
   push
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Build and publish gem
-      uses: jstastny/publish-gem-to-github@v2.1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        owner: acima-credit
+  build-and-push:
+    name: Build And Push Gems
+    uses: upbound-group/ruby-actions/.github/workflows/reusable_push_gems.yml@main  # locking to `main` branch for latest updates for now
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+    with:
+      registry-url: "https://rubygems.pkg.github.com/acima-credit"
+      use-github-token-as-bearer-token: true

--- a/lib/field_struct/avro_schema/version.rb
+++ b/lib/field_struct/avro_schema/version.rb
@@ -2,6 +2,6 @@
 
 module FieldStruct
   module AvroSchema
-    VERSION = '0.1.22'
+    VERSION = '0.1.23'
   end
 end


### PR DESCRIPTION
## [FF-3982](https://acima.atlassian.net/browse/FF-3982)

There was an issue with Ruby Packages failing a little while back.  This updates the workflow to use the new credentials for publishing Ruby Packages.

## TESTING
It publishing the Package is the Test.

[FF-3982]: https://acima.atlassian.net/browse/FF-3982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ